### PR TITLE
Fix libxml2 for 2.9.14

### DIFF
--- a/CVE-2024-34459.patch
+++ b/CVE-2024-34459.patch
@@ -1,0 +1,13 @@
+diff --git a/xmllint.c b/xmllint.c
+index ee6bfdc..29c727e 100644
+--- a/xmllint.c
++++ b/xmllint.c
+@@ -602,7 +602,7 @@ xmlHTMLPrintFileContext(xmlParserInputPtr input) {
+     len = strlen(buffer);
+     snprintf(&buffer[len], sizeof(buffer) - len, "\n");
+     cur = input->cur;
+-    while ((*cur == '\n') || (*cur == '\r'))
++    while ((cur > base) && (*cur == '\n') || (*cur == '\r'))
+ 	cur--;
+     n = 0;
+     while ((cur != base) && (n++ < 80)) {

--- a/prepare_source
+++ b/prepare_source
@@ -1,1 +1,3 @@
-git_src --branch debian/2.12.7+dfsg-3 https://salsa.debian.org/xml-sgml-team/libxml2.git
+git_src --branch debian/2.9.14+dfsg-1 https://salsa.debian.org/xml-sgml-team/libxml2.git
+cp CVE-2024-34459.patch $dir/src/debian/patches/
+echo "CVE-2024-34459.patch" >> $dir/src/debian/patches/series


### PR DESCRIPTION
**What this PR does / why we need it**:
We need for the 1443 release a newer version of libxml2 that was present in the repo. I've 'backported' the patch and fixed the reported vulnerability. 

We'll merge this for a release file, and then we'll update the package in another PR. 
